### PR TITLE
Add Django 1.8 compatibily with the get_queryset method of ModelTagManager

### DIFF
--- a/tagging/managers.py
+++ b/tagging/managers.py
@@ -12,6 +12,9 @@ class ModelTagManager(models.Manager):
     A manager for retrieving tags for a particular model.
     """
     def get_query_set(self):
+        return self.get_queryset()
+
+    def get_queryset(self):
         ctype = ContentType.objects.get_for_model(self.model)
         return Tag.objects.filter(
             items__content_type__pk=ctype.pk).distinct()


### PR DESCRIPTION
`get_query_set` is deprecated in Django 1.8 in favor of `get_queryset`
Keep the `get_query_set` reference for backward compatibility.
